### PR TITLE
Add API testing helper with Schemathesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# API Testing with Schemathesis
+
+This repository contains a helper script to run automated tests for every
+endpoint defined in an OpenAPI/Swagger specification.
+
+The approach relies on the open source tool **[Schemathesis](https://github.com/schemathesis/schemathesis)**
+which generates test cases from your API specification and sends them to the
+running server.
+
+## Requirements
+
+- Python 3.8+
+- `schemathesis` installed (`pip install schemathesis`)
+
+## Usage
+
+1. Start your API server locally or have a reachable base URL.
+2. Run the helper script with the path to your Swagger file and the API's base URL:
+
+```bash
+python run_schemathesis.py path/to/swagger.yaml http://localhost:8000
+```
+
+Schemathesis will automatically generate tests for all endpoints and report any
+failures it encounters.

--- a/run_schemathesis.py
+++ b/run_schemathesis.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def main(spec_path: str, base_url: str) -> None:
+    """Run schemathesis against the given spec and base URL."""
+    cmd = ["schemathesis", "run", spec_path, "--base-url", base_url]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python run_schemathesis.py <spec-path> <base-url>")
+        raise SystemExit(1)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- add `run_schemathesis.py` to execute Schemathesis against a Swagger file
- document how to use the script in a new README

## Testing
- `python run_schemathesis.py`

------
https://chatgpt.com/codex/tasks/task_e_6848884d9788832a9accf33aaaa95c19